### PR TITLE
Language is not detected properly in SpotlightConfiguration

### DIFF
--- a/core/src/main/java/org/dbpedia/spotlight/model/SpotlightConfiguration.java
+++ b/core/src/main/java/org/dbpedia/spotlight/model/SpotlightConfiguration.java
@@ -194,7 +194,7 @@ public class SpotlightConfiguration {
             throw new ConfigurationException("Cannot find POS tagger model file "+taggerFile);
         }
 
-        language = config.getProperty("org.dbpedia.spotlight.data.stopWords", "English");
+        language = config.getProperty("org.dbpedia.spotlight.language", "English");
 
         stopWordsFile = config.getProperty("org.dbpedia.spotlight.data.stopWords."+language.toLowerCase(),"").trim();
         if( (stopWordsFile==null) || !new File(stopWordsFile.trim()).isFile()) {


### PR DESCRIPTION
SpotlightConfiguration because properties key has been wrong.

Committer: reinhard schwab reinhard.schwab@visalyze.com
