### PR TITLE
The right definition of the 'disambiguator' parameter in the Disambiguate rest service

### DIFF
--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/resources/Disambiguate.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/resources/Disambiguate.java
@@ -59,7 +59,7 @@ public class Disambiguate {
                           @DefaultValue(SpotlightConfiguration.DEFAULT_SPARQL) @QueryParam("sparql") String sparqlQuery,
                           @DefaultValue(SpotlightConfiguration.DEFAULT_POLICY) @QueryParam("policy") String policy,
                           @DefaultValue(SpotlightConfiguration.DEFAULT_COREFERENCE_RESOLUTION) @QueryParam("coreferenceResolution") boolean coreferenceResolution,
-                          @DefaultValue("Default") @FormParam("disambiguator") String disambiguatorName,
+                          @DefaultValue("Default") @QueryParam("disambiguator") String disambiguatorName,
                           @Context HttpServletRequest request
     ) {
         String clientIp = request.getRemoteAddr();
@@ -81,7 +81,7 @@ public class Disambiguate {
                           @DefaultValue(SpotlightConfiguration.DEFAULT_SPARQL) @QueryParam("sparql") String sparqlQuery,
                           @DefaultValue(SpotlightConfiguration.DEFAULT_POLICY) @QueryParam("policy") String policy,
                           @DefaultValue(SpotlightConfiguration.DEFAULT_COREFERENCE_RESOLUTION) @QueryParam("coreferenceResolution") boolean coreferenceResolution,
-                          @DefaultValue("Default") @FormParam("disambiguator") String disambiguatorName,
+                          @DefaultValue("Default") @QueryParam("disambiguator") String disambiguatorName,
                           @Context HttpServletRequest request
     ) {
         String clientIp = request.getRemoteAddr();
@@ -103,7 +103,7 @@ public class Disambiguate {
                          @DefaultValue(SpotlightConfiguration.DEFAULT_SPARQL) @QueryParam("sparql") String sparqlQuery,
                          @DefaultValue(SpotlightConfiguration.DEFAULT_POLICY) @QueryParam("policy") String policy,
                          @DefaultValue(SpotlightConfiguration.DEFAULT_COREFERENCE_RESOLUTION) @QueryParam("coreferenceResolution") boolean coreferenceResolution,
-                         @DefaultValue("Default") @FormParam("disambiguator") String disambiguatorName,
+                         @DefaultValue("Default") @QueryParam("disambiguator") String disambiguatorName,
                          @Context HttpServletRequest request
     ) {
         String clientIp = request.getRemoteAddr();
@@ -126,7 +126,7 @@ public class Disambiguate {
                           @DefaultValue(SpotlightConfiguration.DEFAULT_SPARQL) @QueryParam("sparql") String sparqlQuery,
                           @DefaultValue(SpotlightConfiguration.DEFAULT_POLICY) @QueryParam("policy") String policy,
                           @DefaultValue(SpotlightConfiguration.DEFAULT_COREFERENCE_RESOLUTION) @QueryParam("coreferenceResolution") boolean coreferenceResolution,
-                          @DefaultValue("Default") @FormParam("disambiguator") String disambiguatorName,
+                          @DefaultValue("Default") @QueryParam("disambiguator") String disambiguatorName,
                           @Context HttpServletRequest request
     ) {
         String clientIp = request.getRemoteAddr();


### PR DESCRIPTION
As the Disambiguate service accepts only GET requests, I think that all the params should be QueryParams, not FormParams.
