### PR TITLE
allCandidates var

### DIFF
--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TwoStepDisambiguator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TwoStepDisambiguator.scala
@@ -118,14 +118,15 @@ class TwoStepDisambiguator(val candidateSearcher: CandidateSearcher,
 
         LOG.debug("Running bestK for paragraph %s.".format(paragraph.id))
 
-        if (paragraph.occurrences.size==0) return Map[SurfaceFormOccurrence,List[DBpediaResourceOccurrence]]()
-
 //        val m1 = if (candLuceneManager.getDBpediaResourceFactory == null) "lucene" else "jdbc"
 //        val m2 = if (contextLuceneManager.getDBpediaResourceFactory == null) "lucene" else "jdbc"
 
         // step1: get candidates for all surface forms
         //       (TODO here building allCandidates directly, but could extract from occs)
-        var allCandidates = CompactHashSet[DBpediaResource]();
+        var allCandidates = CompactHashSet[DBpediaResource]()
+
+        if (paragraph.occurrences.size==0 || allCandidates.isEmpty) return Map[SurfaceFormOccurrence,List[DBpediaResourceOccurrence]]()
+
         val occs = getCandidates(paragraph,allCandidates)
 
         val s2 = System.nanoTime()


### PR DESCRIPTION
Fixed bug(stacktrace below) when allCandidates var is empty.

org.dbpedia.spotlight.exceptions.SearchException: org.dbpedia.spotlight.exceptions.SearchException: Error searching for surface form CONTEXT:brilh CONTEXT:jog CONTEXT:particip CONTEXT:par CONTEXT:dos  at org.dbpedia.spotlight.disambiguate.TwoStepDisambiguator.bestK(TwoStepDisambiguator.scala:137)...
