### PR TITLE
[Fixed] Duplicate entry in Index POM (commons-compress)

### DIFF
--- a/index/pom.xml
+++ b/index/pom.xml
@@ -271,11 +271,6 @@
         </dependency>
 
         <dependency>
-        	<groupId>org.apache.commons</groupId>
-        	<artifactId>commons-compress</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
         </dependency>


### PR DESCRIPTION
Fixing the issue below:

Some problems were encountered while building the effective model for org.dbpedia.spotlight:index:jar:0.6
'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.commons:commons-compress:jar -> version 1.4.1 vs (?) @ line 273, column 21

It is highly recommended to fix these problems because they threaten the stability of your build.

For this reason, future Maven versions might no longer support building such malformed projects.
