### PR TITLE
Removing ScalaJ dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -211,11 +211,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.scalaj</groupId>
-            <artifactId>scalaj-collection_2.9.1</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.mahout</groupId>
             <artifactId>mahout-collections</artifactId>
         </dependency>

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/CuttingEdgeDisambiguator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/CuttingEdgeDisambiguator.scala
@@ -22,7 +22,7 @@ import org.dbpedia.spotlight.exceptions.{SearchException, InputException}
 import org.apache.lucene.search.Explanation
 import org.dbpedia.spotlight.model._
 import org.dbpedia.spotlight.lucene.disambiguate.MixedWeightsDisambiguator
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 
 /**
  * Implementation used for evaluation runs. Will change as new scores/implementations come in.

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/DefaultDisambiguator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/DefaultDisambiguator.scala
@@ -26,7 +26,7 @@ import org.apache.lucene.search.Explanation
 import org.dbpedia.spotlight.model._
 import org.dbpedia.spotlight.lucene.disambiguate.{MixedWeightsDisambiguator, MergedOccurrencesDisambiguator}
 import org.dbpedia.spotlight.exceptions.{ItemNotFoundException, SearchException, InputException}
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
 
 /**
@@ -78,7 +78,6 @@ class DefaultDisambiguator(val contextSearcher: ContextSearcher) extends Disambi
      * Executes disambiguation per occurrence, returns a list of possible candidates.
      * Can be seen as a ranking (rather than classification) task: query instance in, ranked list of target URIs out.
      *
-     * @param sfOccurrences
      * @param k
      * @return
      * @throws org.dbpedia.spotlight.exceptions.SearchException

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/MultiThreadedDisambiguatorWrapper.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/MultiThreadedDisambiguatorWrapper.scala
@@ -34,7 +34,7 @@ package org.dbpedia.spotlight.disambiguate
  * limitations under the License.
  */
 
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import org.apache.commons.logging.LogFactory
 import org.apache.lucene.search.Explanation
 import org.dbpedia.spotlight.model._

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/ParagraphDisambiguatorJ.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/ParagraphDisambiguatorJ.scala
@@ -22,7 +22,7 @@ import org.dbpedia.spotlight.exceptions.InputException
 import org.dbpedia.spotlight.exceptions.ItemNotFoundException
 import org.dbpedia.spotlight.exceptions.SearchException
 import org.dbpedia.spotlight.model._
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import java.util.HashMap
 
 /**

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TopicBiasedDisambiguator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TopicBiasedDisambiguator.scala
@@ -20,7 +20,7 @@ package org.dbpedia.spotlight.disambiguate
 
 import org.apache.commons.logging.LogFactory
 import java.lang.UnsupportedOperationException
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import org.apache.lucene.search.similar.MoreLikeThis
 import org.dbpedia.spotlight.exceptions.{ItemNotFoundException, SearchException, InputException}
 import org.apache.lucene.search.{ScoreDoc, Explanation}

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TopicalDisambiguator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TopicalDisambiguator.scala
@@ -21,7 +21,7 @@ package org.dbpedia.spotlight.disambiguate
 import org.apache.commons.logging.LogFactory
 import org.dbpedia.spotlight.lucene.disambiguate.MergedOccurrencesDisambiguator
 import java.lang.UnsupportedOperationException
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import org.apache.lucene.search.similar.MoreLikeThis
 import org.dbpedia.spotlight.exceptions.{ItemNotFoundException, SearchException, InputException}
 import org.apache.lucene.search.{ScoreDoc, Explanation}

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TwoStepDisambiguator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/TwoStepDisambiguator.scala
@@ -21,7 +21,7 @@ package org.dbpedia.spotlight.disambiguate
 import org.apache.commons.logging.LogFactory
 import org.dbpedia.spotlight.lucene.disambiguate.MergedOccurrencesDisambiguator
 import java.lang.UnsupportedOperationException
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import org.apache.lucene.search.similar.MoreLikeThis
 import org.dbpedia.spotlight.exceptions.{ItemNotFoundException, SearchException, InputException}
 import org.apache.lucene.search.{ScoreDoc, Explanation}
@@ -147,7 +147,7 @@ class TwoStepDisambiguator(val candidateSearcher: CandidateSearcher,
             var score = hit.score
             //TODO can mix here the scores: c(s,r) / c(r)
             acc + (resource.uri -> (resource,score))
-        });
+        })
         val e2 = System.nanoTime()
         //LOG.debug("Scores (%d): %s".format(scores.size, scores))
 

--- a/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/CombineAllAnnotationFilters.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/CombineAllAnnotationFilters.scala
@@ -20,7 +20,7 @@ import org.apache.commons.logging.LogFactory
 import org.dbpedia.spotlight.model._
 import org.dbpedia.spotlight.sparql.SparqlQueryExecuter
 import scala.collection.JavaConversions._
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 
 class CombineAllAnnotationFilters(val config: SpotlightConfiguration) {
 

--- a/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/SparqlFilter.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/SparqlFilter.scala
@@ -21,7 +21,7 @@ package org.dbpedia.spotlight.filter.annotations
 import org.apache.commons.logging.LogFactory
 import org.dbpedia.spotlight.model.{DBpediaResource, DBpediaResourceOccurrence}
 import org.dbpedia.spotlight.sparql.SparqlQueryExecuter
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 
 
 class SparqlFilter(val executer : SparqlQueryExecuter, val sparqlQuery: String, val listColor : FilterPolicy.ListColor) extends AnnotationFilter  {

--- a/core/src/main/scala/org/dbpedia/spotlight/model/Factory.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/model/Factory.scala
@@ -31,7 +31,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.dbpedia.spotlight.lucene.similarity.{CachedInvCandFreqSimilarity, JCSTermCache, InvCandFreqSimilarity}
 import org.apache.lucene.misc.SweetSpotSimilarity
 import org.apache.lucene.search.{DefaultSimilarity, ScoreDoc, Similarity}
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import org.dbpedia.spotlight.spot.{SpotSelector, AtLeastOneNounSelector, ShortSurfaceFormSelector}
 import java.io.File
 import org.dbpedia.extraction.util.WikiUtil

--- a/core/src/main/scala/org/dbpedia/spotlight/model/Paragraph.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/model/Paragraph.scala
@@ -37,7 +37,7 @@ package org.dbpedia.spotlight.model
  */
 
 import org.apache.commons.lang.NotImplementedException
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 /**
  * Class to give a perspective of text items (e.g. paragraphs) containing surface form occurrences to be annotated,
  * instead of the perspective of occurrences that hold a paragraph.

--- a/core/src/main/scala/org/dbpedia/spotlight/spot/AtLeastOneNounSelector.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/spot/AtLeastOneNounSelector.scala
@@ -21,7 +21,7 @@ package org.dbpedia.spotlight.spot
 import com.aliasi.sentences.IndoEuropeanSentenceModel
 import java.io.File
 import org.dbpedia.spotlight.tagging.lingpipe.{LingPipeTaggedTokenProvider, LingPipeFactory}
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 
 import org.apache.commons.logging.LogFactory
 import org.dbpedia.spotlight.model._

--- a/core/src/main/scala/org/dbpedia/spotlight/spot/SurfaceFormWhitelistSelector.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/spot/SurfaceFormWhitelistSelector.scala
@@ -17,7 +17,7 @@
 
 package org.dbpedia.spotlight.spot
 
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import org.apache.commons.logging.LogFactory
 import org.dbpedia.spotlight.model._
 import scala.io.Source._

--- a/core/src/main/scala/org/dbpedia/spotlight/spot/opennlp/OpenNLPChunkerSpotter.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/spot/opennlp/OpenNLPChunkerSpotter.scala
@@ -1,6 +1,6 @@
 package org.dbpedia.spotlight.spot.opennlp
 
-
+import scala.collection.JavaConverters._
 import org.dbpedia.spotlight.spot.{OpenNLPUtil, Spotter}
 import opennlp.tools.chunker.{ChunkerModel, ChunkerME, Chunker}
 import java.io.FileInputStream
@@ -13,7 +13,7 @@ import scala.util.control.Breaks._
 import org.dbpedia.spotlight.model.{SurfaceForm, SurfaceFormOccurrence, Text}
 import collection.mutable.HashSet
 import io.Source
-import scalaj.collection.Implicits._
+
 
 
 /**

--- a/core/src/test/scala/org/dbpedia/spotlight/disambiguate/MultithreadedDisambiguatorTest.scala
+++ b/core/src/test/scala/org/dbpedia/spotlight/disambiguate/MultithreadedDisambiguatorTest.scala
@@ -22,7 +22,7 @@ import org.dbpedia.spotlight.model.{DBpediaResourceOccurrence, SurfaceFormOccurr
 import actors._
 import actors.Actor._
 import org.junit.Test
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 
 /**
  * TODO build real test with disambiguators

--- a/eval/src/main/scala/org/dbpedia/spotlight/evaluation/EvaluateParagraphDisambiguator.scala
+++ b/eval/src/main/scala/org/dbpedia/spotlight/evaluation/EvaluateParagraphDisambiguator.scala
@@ -27,7 +27,7 @@ import org.dbpedia.spotlight.model._
 import org.dbpedia.spotlight.filter.occurrences.{UriWhitelistFilter, RedirectResolveFilter, OccurrenceFilter}
 import scala.Some
 
-import scalaj.collection.Imports._
+
 
 
 /**

--- a/eval/src/test/scala/org/dbpedia/spotlight/evaluation/corpus/TestCorpora.scala
+++ b/eval/src/test/scala/org/dbpedia/spotlight/evaluation/corpus/TestCorpora.scala
@@ -12,7 +12,7 @@ import java.io.File
  */
 
 class TestCorpora extends FlatSpec with ShouldMatchers {
-    implicit def stringToFile(s: String) = new File(s)
+  implicit def stringToFile(s: String) = new File(s)
 
   val queryFile = new File("/mnt/windows/Extra/Researches/data/kbp/queries/TAC_2010_KBP_Evaluation_Entity_Linking_Gold_Standard_V1.0/TAC_2010_KBP_Evaluation_Entity_Linking_Gold_Standard_V1.1/data/tac_2010_kbp_evaluation_entity_linking_queries.xml")
   val annotationFile = new File("/mnt/windows/Extra/Researches/data/kbp/queries/TAC_2010_KBP_Evaluation_Entity_Linking_Gold_Standard_V1.0/TAC_2010_KBP_Evaluation_Entity_Linking_Gold_Standard_V1.1/data/tac_2010_kbp_evaluation_entity_linking_query_types.tab")
@@ -21,22 +21,22 @@ class TestCorpora extends FlatSpec with ShouldMatchers {
 
 
   val corpora = List(MilneWittenCorpus.fromDirectory("/home/pablo/eval/wikify/original/"),
-                         AidaCorpus.fromFile("/home/pablo/eval/aida/gold/CoNLL-YAGO.tsv"),
-                         new KBPCorpus(queryFile,annotationFile,sourceDir,kbDir)
+    AidaCorpus.fromFile("/home/pablo/eval/aida/gold/CoNLL-YAGO.tsv"),
+    new KBPCorpus(queryFile, annotationFile, sourceDir, kbDir)
   )
 
 
-    corpora.foreach( corpus => {
-        corpus.getClass.getSimpleName.trim should "have correct offsets" in {
-            corpus.foreach( p => {
-                p.occurrences.foreach( o => {
-                    val stored = o.surfaceForm.name
-                    val actual = o.context.text.substring(o.textOffset,o.textOffset+stored.length)
-                    stored should equal (actual)
-                })
-            })
-        }
-    })
+  corpora.foreach(corpus => {
+    corpus.getClass.getSimpleName.trim should "have correct offsets" in {
+      corpus.foreach(p => {
+        p.occurrences.foreach(o => {
+          val stored = o.surfaceForm.name
+          val actual = o.context.text.substring(o.textOffset, o.textOffset + stored.length)
+          stored should equal(actual)
+        })
+      })
+    }
+  })
 
 
 }

--- a/index/pom.xml
+++ b/index/pom.xml
@@ -231,11 +231,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.scalaj</groupId>
-            <artifactId>scalaj-collection_2.9.1</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.mahout</groupId>
             <artifactId>mahout-collections</artifactId>
         </dependency>

--- a/index/src/main/scala/org/dbpedia/spotlight/lucene/index/AddCountsToIndex.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/lucene/index/AddCountsToIndex.scala
@@ -36,7 +36,7 @@ package org.dbpedia.spotlight.lucene.index
  *
  */
 
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import org.dbpedia.spotlight.util.IndexingConfiguration
 import java.io.File
 import io.Source
@@ -93,7 +93,7 @@ object AddCountsToIndex {
 
         val sfIndexer = new IndexEnricher(sourceIndexFileName,targetIndexFileName,config)
 
-        val counts = loadCounts(countsFileName)
+        val counts : java.util.Map[String, java.lang.Integer]= loadCounts(countsFileName).asInstanceOf[java.util.Map[String, java.lang.Integer]]
         LOG.info("Adding to index.")
         sfIndexer.enrichWithCounts(counts)
         LOG.info("Done.")

--- a/index/src/main/scala/org/dbpedia/spotlight/lucene/index/AddSurfaceFormsToIndex.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/lucene/index/AddSurfaceFormsToIndex.scala
@@ -25,7 +25,7 @@ import org.dbpedia.spotlight.util.IndexingConfiguration
 import java.util.Scanner
 import java.io.FileInputStream
 import org.apache.commons.logging.{LogFactory, Log}
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 
 /**
  * In our first implementation we used to index all anchor text found in Wikipedia as surface forms to a target URI.

--- a/index/src/main/scala/org/dbpedia/spotlight/lucene/index/PatchIndex.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/lucene/index/PatchIndex.scala
@@ -18,7 +18,6 @@
 
 package org.dbpedia.spotlight.lucene.index
 
-import scalaj.collection.Imports._
 import org.dbpedia.spotlight.lucene.LuceneManager
 import io.Source
 import org.dbpedia.spotlight.model.DBpediaResource
@@ -67,7 +66,7 @@ object PatchIndex {
         val sfIndexer = new IndexEnricher(sourceIndexFileName, targetIndexFileName, config)
 
         val typesMap = AddTypesToIndex.loadTypes(instanceTypesFileName);
-        val countsMap = AddCountsToIndex.loadCounts(countsFileName)
+        val countsMap: java.util.Map[String, java.lang.Integer] = AddCountsToIndex.loadCounts(countsFileName).asInstanceOf[java.util.Map[String, java.lang.Integer]]
         val sfMap = AddSurfaceFormsToIndex.loadSurfaceForms(surfaceFormsFileName, AddSurfaceFormsToIndex.fromTitlesToAlternatives)
 
         LOG.info("Expunge deletes.")

--- a/pom.xml
+++ b/pom.xml
@@ -616,15 +616,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.scalaj</groupId>
-                <artifactId>scalaj-collection_2.9.1</artifactId>
-                <version>1.2</version>
-                <!--
-                    License: Apache Software License, Version 2.0
-                -->
-            </dependency>
-
-            <dependency>
                 <groupId>trove</groupId>
                 <artifactId>trove</artifactId>
                 <version>1.1-beta-5</version>

--- a/rest/src/main/scala/org/dbpedia/spotlight/web/rest/RelatedResources.scala
+++ b/rest/src/main/scala/org/dbpedia/spotlight/web/rest/RelatedResources.scala
@@ -37,7 +37,7 @@ import com.sun.jersey.api.container.grizzly.GrizzlyWebContainerFactory
 import related.Related
 
 import org.dbpedia.spotlight.sparql.SparqlQueryExecuter
-import scalaj.collection.Imports._
+import scala.collection.JavaConverters._
 import collection.mutable.{Map, HashMap}
 import collection.Set
 


### PR DESCRIPTION
- Replacing import scalaj.collection.Imports._ to a native Scala implementation: import scala.collection.JavaConverters._
- Removing ScalaJ from the pom files
- Forcing casting when Java Types is required
  E.g.:
       java.util.Map[String, java.lang.Integer] instead of java.util.Map[String, Int]
