### PR TITLE
Fixes the parameter passing inside SpotlightLog.scala

### DIFF
--- a/core/src/main/scala/org/dbpedia/spotlight/log/SpotlightLog.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/log/SpotlightLog.scala
@@ -13,20 +13,20 @@ trait SpotlightLog[T] {
 
 object SpotlightLog {
   def debug[T](c:Class[_], msg: T, args: Any*)(implicit instance: SpotlightLog[T]) =
-    instance._debug(c, msg, args)
+    instance._debug(c, msg, args: _*)
   def info[T](c:Class[_], msg: T, args: Any*)(implicit instance: SpotlightLog[T]) =
-    instance._info(c, msg, args)
+    instance._info(c, msg, args: _*)
   def error[T](c:Class[_], msg: T, args: Any*)(implicit instance: SpotlightLog[T]) =
-    instance._error(c, msg, args)
+    instance._error(c, msg, args: _*)
   def fatal[T](c:Class[_], msg: T, args: Any*)(implicit instance: SpotlightLog[T]) =
-    instance._fatal(c, msg, args)
+    instance._fatal(c, msg, args: _*)
   def trace[T](c:Class[_], msg: T, args: Any*)(implicit instance: SpotlightLog[T]) =
-    instance._trace(c, msg, args)
+    instance._trace(c, msg, args: _*)
   def warn[T](c:Class[_], msg: T, args: Any*)(implicit instance: SpotlightLog[T]) =
-    instance._warn(c, msg, args)
+    instance._warn(c, msg, args: _*)
 
   implicit object StringSpotlightLog extends SpotlightLog[String] {
-    def _debug(c:Class[_], msg: String, args: Any*)  {
+    def _debug(c:Class[_], msg: String, args: Any*) = {
       @transient lazy val log = LogFactory.getLog(c)
       if (log.isDebugEnabled)
         if(args.size == 0)
@@ -34,7 +34,7 @@ object SpotlightLog {
         else
           log.debug(msg.format(args: _*))
     }
-    def _info(c:Class[_], msg: String, args: Any*) {
+    def _info(c:Class[_], msg: String, args: Any*) = {
       @transient lazy val log = LogFactory.getLog(c)
       if(log.isInfoEnabled)
         if(args.size == 0)
@@ -42,7 +42,7 @@ object SpotlightLog {
         else
           log.info(msg.format(args: _*))
     }
-    def _error(c:Class[_], msg: String, args: Any*) {
+    def _error(c:Class[_], msg: String, args: Any*) = {
       @transient lazy val log = LogFactory.getLog(c)
       if(log.isErrorEnabled)
         if(args.size == 0)
@@ -50,7 +50,7 @@ object SpotlightLog {
         else
           log.error(msg.format(args: _*))
     }
-    def _fatal(c:Class[_], msg: String, args: Any*) {
+    def _fatal(c:Class[_], msg: String, args: Any*) = {
       @transient lazy val log = LogFactory.getLog(c)
       if(log.isFatalEnabled)
         if(args.size == 0)
@@ -58,7 +58,7 @@ object SpotlightLog {
         else
           log.fatal(msg.format(args: _*))
     }
-    def _trace(c:Class[_], msg: String, args: Any*) {
+    def _trace(c:Class[_], msg: String, args: Any*) = {
       @transient lazy val log = LogFactory.getLog(c)
       if(log.isTraceEnabled)
         if(args.size == 0)
@@ -66,7 +66,7 @@ object SpotlightLog {
         else
           log.trace(msg.format(args: _*))
     }
-    def _warn(c:Class[_], msg: String, args: Any*) {
+    def _warn(c:Class[_], msg: String, args: Any*) = {
       @transient lazy val log = LogFactory.getLog(c)
       if(log.isWarnEnabled)
         if(args.size == 0)
@@ -75,4 +75,4 @@ object SpotlightLog {
           log.warn(msg.format(args: _*))
     }
   }
-}	
+}


### PR DESCRIPTION
This pull-request fixes issues #225 and #226. And many other problems using the new LOG class, which should appear. 

As used at other parts of the same, the parameter passing to functions like f(arg: T_) must be as g(arg: __ ) [1]. 

The = at: " def _xyz (..) = { ... " is not obligatory in that code, but was used to maintain the scala standard function declaration.
## 

[1] http://stackoverflow.com/questions/8000903/what-are-all-the-uses-of-an-underscore-in-scala
