### PR TITLE
Add DBpediaSpotlightClient.java back and rename translated to scala clients

### DIFF
--- a/eval/src/main/java/org/dbpedia/spotlight/evaluation/external/DBpediaSpotlightClient.java
+++ b/eval/src/main/java/org/dbpedia/spotlight/evaluation/external/DBpediaSpotlightClient.java
@@ -104,8 +104,9 @@ public class DBpediaSpotlightClient extends AnnotationClient {
 //        File input = new File("/home/pablo/eval/wikify/gold/WikifyAllInOne.txt");
 //        File output = new File("/home/pablo/eval/wikify/systems/Spotlight.list");
 
-        File input = new File("/home/pablo/eval/csaw/gold/paragraphs.txt");
-        File output = new File("/home/pablo/eval/csaw/systems/Spotlight.list");
+        File input = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Berlin.txt");
+        File output = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Spotlight.list");
+
 
         c.evaluate(input, output);
 

--- a/eval/src/main/scala/org/dbpedia/spotlight/evaluation/external/AlchemyClient.scala
+++ b/eval/src/main/scala/org/dbpedia/spotlight/evaluation/external/AlchemyClient.scala
@@ -37,7 +37,7 @@ import scala.collection.immutable.List
   * Tested for English and Portuguese, ok for both.
   */
 
-class AlchemyClientScala(apikey: String) extends AnnotationClientScala {
+class AlchemyClient(apikey: String) extends AnnotationClientScala {
 
   val url: String = "http://access.alchemyapi.com/calls/text/TextGetRankedNamedEntities"
 
@@ -90,19 +90,19 @@ class AlchemyClientScala(apikey: String) extends AnnotationClientScala {
 }
 
 
-object AlchemyClientScala {
+object AlchemyClient {
 
   def main(args: Array[String]) {
     val apikey: String = args(0)
 
-    val alchemyClient = new AlchemyClientScala(apikey)
+    val alchemyClient = new AlchemyClient(apikey)
 
-    val input = new File("/home/alexandre/Projects/Test_Files/Caminhao.txt")
-    val output = new File("/home/alexandre/Projects/Test_Files/Alchemy-scala_Caminhao.list")
+    val input = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Caminhao.txt")
+    val output = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Alchemy-scala_Caminhao.list")
     alchemyClient.evaluate(input, output)
 
-    val inputEng = new File("/home/alexandre/Projects/Test_Files/Germany.txt")
-    val outputEng = new File("/home/alexandre/Projects/Test_Files/Alchemy-scala_Germany.list")
+    val inputEng = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Berlin.txt")
+    val outputEng = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Alchemy-scala_Berlin.list")
     alchemyClient.evaluate(inputEng, outputEng)
   }
 

--- a/eval/src/main/scala/org/dbpedia/spotlight/evaluation/external/ZemantaClient.scala
+++ b/eval/src/main/scala/org/dbpedia/spotlight/evaluation/external/ZemantaClient.scala
@@ -39,9 +39,9 @@ import java.io.{File, IOException}
  * (Zemanta service support only English language.)
  */
 
-class ZemantaClientScala(api_key: String) extends AnnotationClientScala {
+class ZemantaClient(api_key: String) extends AnnotationClientScala {
 
-  override val LOG: Log = LogFactory.getLog(classOf[ZemantaClientScala])
+  override val LOG: Log = LogFactory.getLog(classOf[ZemantaClient])
 
   /**
    * DISCLAIMER these are not really promised by Zemanta to be DBpediaEntities. We extract them from wikipedia links.
@@ -93,19 +93,19 @@ class ZemantaClientScala(api_key: String) extends AnnotationClientScala {
 }
 
 
-object ZemantaClientScala {
+object ZemantaClient {
 
   def main(args: Array[String]) {
 
     val api_key: String = args(0)
-    val c = new ZemantaClientScala(api_key)
+    val c = new ZemantaClient(api_key)
 
-    val input: File = new File("/home/alexandre/Projects/Test_Files/Caminhao.txt")
-    val output: File = new File("/home/alexandre/Projects/Test_Files/Zemanta-scala_Caminhao.list")
+    val input: File = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Caminhao.txt")
+    val output: File = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Zemanta-scala_Caminhao.list")
     c.evaluate(input, output)
 
-    val inputEng: File = new File("/home/alexandre/Projects/Test_Files/Germany.txt")
-    val outputEng: File = new File("/home/alexandre/Projects/Test_Files/Zemanta-scala_Germany.list")
+    val inputEng: File = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Berlin.txt")
+    val outputEng: File = new File("/home/alexandre/Projects/test-files-spotlight/ExternalClients_TestFiles/Zemanta-scala_Berlin.list")
     c.evaluate(inputEng, outputEng)
 
   }


### PR DESCRIPTION
This pull request fixes issue #239. By adding back the DBpediaSpotlightClient.java and rename the translated to scala clients (to be without Scala in their names).

The AnnotationClientScala.scala and the DBpediaSpotlightClientScala.scala can not be renamed, because the old java versions were not deleted (the first is the father abstract class and the second because it was requested as issue 239). And, so, if Scala was take off their names, as all clients both java and scala are in the same package it would generate a class name conflict.
