### PR TITLE
Increase server keep alive from 5 to 30 min

### DIFF
--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/Server.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/Server.java
@@ -111,6 +111,7 @@ public class Server {
 
 
         SelectorThread threadSelector = GrizzlyWebContainerFactory.create(serverURI, initParams);
+        threadSelector.setTransactionTimeout(30 * 60 * 1000); // 30 minutes
         threadSelector.start();
 
         System.err.println("Server started in " + System.getProperty("user.dir") + " listening on " + serverURI);


### PR DESCRIPTION
The default grizzly timeout is 5 minutes. 
This can be insufficient for very large requests. especially with the slower Lucene version. This problem has also been reported in #247.
Therefore I increased it to 30 minutes and tested it successfully on my fork.
