### PR TITLE
Tokenize text after spotting in Candidates.

### DIFF
--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/resources/Candidates.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/resources/Candidates.java
@@ -86,6 +86,9 @@ public class Candidates {
 
         List<SurfaceFormOccurrence> entityMentions = spotter.extract(textObject);
         if (entityMentions.size()==0) return annotation; //nothing to disambiguate
+        if(Server.getTokenizer() != null)
+            Server.getTokenizer().tokenizeMaybe(entityMentions.get(0).context());
+
         Paragraph paragraph = Factory.paragraph().fromJ(entityMentions);
         LOG.info(String.format("Spotted %d entity mentions.",entityMentions.size()));
 


### PR DESCRIPTION
SpotlightInterface (the implementation of the 'disambiguate' and
'annotate' endpoints) tokenizes the input text twice, before and after
performing soptting, respectively. The 'candidates' endpoint, however,
tokenizes the input text just once (before spotting). This causes
problems when calling 'candidates' while passing the 'SpotXmlParser'
spotter, which returns no output.

This commit fixes this bug by tokenizing the text after spotting in
Candidates.java, just like in the SpotlightInterface.java case.
