### PR TITLE
Fixing - Sparql bug 

### DIFF
--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/Server.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/Server.java
@@ -223,7 +223,7 @@ public class Server {
     private static void setSparqlExecuter(String endpoint, String graph)
     {
         if (endpoint == null || endpoint.equals(""))  endpoint= "http://dbpedia.org/sparql";
-        if (graph == null || graph.equals(""))  endpoint= "http://dbpedia.org";
+        if (graph == null || graph.equals(""))  graph= "http://dbpedia.org";
 
         Server.sparqlExecuter = new SparqlQueryExecuter(graph, endpoint);
     }


### PR DESCRIPTION
The `graph` param passed to `SparqlQueryExecuter` would be empty all times so any request filtering using sparql queries would return exceptions like : https://gist.github.com/dav009/485b6c2281247669ff89

Here is a sample I query I ran which generate errors in the current master branch, and seems to be fixed with this patch: https://gist.github.com/dav009/3a8eb39dabbc9b4903a8
