### PR TITLE
uima: don't query endpoint without text (crashes otherwise)

### DIFF
--- a/uima/src/main/java/org/dbpedia/spotlight/uima/SpotlightAnnotator.java
+++ b/uima/src/main/java/org/dbpedia/spotlight/uima/SpotlightAnnotator.java
@@ -71,6 +71,11 @@ public class SpotlightAnnotator extends JCasAnnotator_ImplBase {
 	public void process(JCas aJCas) throws AnalysisEngineProcessException {
 		String documentText = aJCas.getDocumentText();
 
+		// don't query endpoint without text
+		if (documentText == null || documentText.isEmpty()) {
+			return;
+		}
+
 		Client c = Client.create();
 
 		BufferedReader documentReader = new BufferedReader(new StringReader(documentText));

--- a/uima/src/main/java/org/dbpedia/spotlight/uima/SpotlightAnnotator.java
+++ b/uima/src/main/java/org/dbpedia/spotlight/uima/SpotlightAnnotator.java
@@ -102,6 +102,9 @@ public class SpotlightAnnotator extends JCasAnnotator_ImplBase {
 				request += line;
 				numLines++;
 			}
+			if (request == null || request.isEmpty()) {
+				break;
+			}
 
 			
 			Annotation response = null;


### PR DESCRIPTION
SpotlightAnnotator creates an invalid request when the document text is empty.