### PR TITLE
Fix tokentype id conflict

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -138,7 +138,7 @@
 
         <dependency>
             <groupId>net.liftweb</groupId>
-            <artifactId>lift-json_${scala.compiler.version}</artifactId>
+            <artifactId>lift-json_2.10</artifactId>
         </dependency>
 
         <dependency>
@@ -192,7 +192,7 @@
 
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.compiler.version}</artifactId>
+            <artifactId>scalatest_2.10</artifactId>
         </dependency>
 
         <dependency>
@@ -227,17 +227,17 @@
 
         <dependency>
             <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-core_${scala.compiler.version}</artifactId>
+            <artifactId>scalaz-core_2.10</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.scalanlp</groupId>
-            <artifactId>breeze-learn_${scala.compiler.version}</artifactId>
+            <artifactId>breeze-learn_2.10</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor</artifactId>
+            <artifactId>akka-actor_2.10</artifactId>
         </dependency>
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -236,6 +236,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-actors</artifactId>
+            <version>2.10.5</version>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-actor_2.10</artifactId>
         </dependency>

--- a/core/src/main/scala/org/dbpedia/spotlight/annotate/DefaultAnnotator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/annotate/DefaultAnnotator.scala
@@ -21,7 +21,7 @@ import org.dbpedia.spotlight.model._
 import org.dbpedia.spotlight.spot.Spotter
 import org.dbpedia.spotlight.exceptions.InputException
 import scala.collection.JavaConversions._
-import org.dbpedia.spotlight.disambiguate.{ParagraphDisambiguatorJ, ParagraphDisambiguator, Disambiguator}
+import org.dbpedia.spotlight.disambiguate.{ParagraphDisambiguatorJ, Disambiguator}
 import java.util
 
 /**
@@ -58,7 +58,7 @@ class DefaultParagraphAnnotator(val spotter : Spotter, val disambiguator: Paragr
     def annotate(text : String) : java.util.List[DBpediaResourceOccurrence] = {
 
         SpotlightLog.info(this.getClass, "Spotting... (%s)", spotter.getName)
-        val spottedSurfaceForms : List[SurfaceFormOccurrence] = asBuffer(spotter.extract(new Text(text))).toList
+        val spottedSurfaceForms : List[SurfaceFormOccurrence] = asScalaBuffer(spotter.extract(new Text(text))).toList
 
         SpotlightLog.info(this.getClass, "Disambiguating... (%s)", disambiguator.name)
         val disambiguatedOccurrences : java.util.List[DBpediaResourceOccurrence] = {

--- a/core/src/main/scala/org/dbpedia/spotlight/db/SpotlightModel.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/db/SpotlightModel.scala
@@ -107,10 +107,7 @@ object SpotlightModel {
         tokenTypeStore
       ).asInstanceOf[TextTokenizer]
 
-      if(cores.size == 1)
-        createTokenizer()
-      else
-        new TokenizerWrapper(cores.map(_ => createTokenizer())).asInstanceOf[TextTokenizer]
+      createTokenizer()
 
     } else {
       val locale = properties.getProperty("locale").split("_")
@@ -147,12 +144,8 @@ object SpotlightModel {
         Some(loadSpotterThresholds(new File(modelFolder, "spotter_thresholds.txt")))
       ).asInstanceOf[Spotter]
 
-      if(cores.size == 1)
-        createSpotter()
-      else
-        new SpotterWrapper(
-          cores.map(_ => createSpotter())
-        ).asInstanceOf[Spotter]
+
+      createSpotter()
 
     } else {
       val dict = MemoryStore.loadFSADictionary(new FileInputStream(new File(modelFolder, "fsa_dict.mem")))

--- a/core/src/main/scala/org/dbpedia/spotlight/disambiguate/DefaultDisambiguator.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/disambiguate/DefaultDisambiguator.scala
@@ -69,7 +69,7 @@ class DefaultDisambiguator(val contextSearcher: ContextSearcher) extends Disambi
      * @throws org.dbpedia.spotlight.exceptions.InputException
      */
     def disambiguate(paragraph: Paragraph): List[DBpediaResourceOccurrence] = {
-        asBuffer(disambiguator.disambiguate(paragraph.occurrences.asJava)).toList
+        asScalaBuffer(disambiguator.disambiguate(paragraph.occurrences.asJava)).toList
     }
 
     /**

--- a/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/AnnotationFilter.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/AnnotationFilter.scala
@@ -17,7 +17,6 @@
 package org.dbpedia.spotlight.filter.annotations
 
 import org.dbpedia.spotlight.filter.Filter
-import org.dbpedia.spotlight.model.DBpediaResourceOccurrence
 
 /**
  * Filter result annotations based on scores, types, SPARQL queries etc.

--- a/core/src/main/scala/org/dbpedia/spotlight/io/AnnotatedTextSource.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/io/AnnotatedTextSource.scala
@@ -15,16 +15,13 @@
  */
 package org.dbpedia.spotlight.io
 
-import org.dbpedia.spotlight.model._
-import io.Source
 import java.io._
-import java.util.zip.{GZIPOutputStream, GZIPInputStream}
-import tools.nsc.doc.model.comment.Paragraph
+import java.util.zip.GZIPInputStream
+
 import org.apache.commons.lang.NotImplementedException
-import scala.collection.JavaConversions._
-import java.util.ArrayList
-import org.junit.Test
-import java.text.ParseException
+import org.dbpedia.spotlight.model._
+
+import scala.io.Source
 
 /**
  * Reads *SORTED* DBpediaResourceOccurrences from TSV files and converts them to paragraphs that hold N occurrences.

--- a/core/src/main/scala/org/dbpedia/spotlight/io/WikiPageCaseClass.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/io/WikiPageCaseClass.scala
@@ -2,9 +2,11 @@ package org.dbpedia.spotlight.io
 
 import org.dbpedia.extraction.sources.WikiPage
 
+
 object WikiPageUtil {
     def copyWikiPage(wikiPage: WikiPage, source: String) = {
-        new WikiPage(wikiPage.title, wikiPage.redirect, wikiPage.id, wikiPage.revision, wikiPage.timestamp, source)
+        new WikiPage(wikiPage.title, wikiPage.redirect, wikiPage.id, wikiPage.revision, wikiPage.timestamp,
+                     wikiPage.contributorID, wikiPage.contributorName, source, wikiPage.format)
     }
 }
 

--- a/core/src/main/scala/org/dbpedia/spotlight/model/OntologyType.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/model/OntologyType.scala
@@ -18,7 +18,7 @@
 
 package org.dbpedia.spotlight.model
 
-import java.lang.{Short, String}
+import java.lang.Short
 
 /**
  * Representation of types (DBpedia, Freebase, Schema.org, etc.)
@@ -57,7 +57,7 @@ trait OntologyType extends Serializable {
  */
 
 
-@SerialVersionUID(8037662401509425326l)
+@SerialVersionUID(8037662401509425326L)
 class DBpediaType(var name : String) extends OntologyType {
 
     name = name.replace(DBpediaType.DBPEDIA_ONTOLOGY_PREFIX, "")
@@ -72,8 +72,8 @@ class DBpediaType(var name : String) extends OntologyType {
         name.equalsIgnoreCase(that.name)
     }
 
-    override def getFullUri =  if (name.toLowerCase.startsWith("http")) name else DBpediaType.DBPEDIA_ONTOLOGY_PREFIX + name
-    override def typeID = if (name.toLowerCase.startsWith("http")) name else "DBpedia:".concat(name)
+    override def getFullUri =  if (name.substring(0,4).equalsIgnoreCase("http")) name else DBpediaType.DBPEDIA_ONTOLOGY_PREFIX + name
+    override def typeID = if (name.substring(0,4).equalsIgnoreCase("http")) name else "DBpedia:".concat(name)
 
 }
 
@@ -87,7 +87,7 @@ object DBpediaType {
  * Types from Freebase: non-hierarchical, grouped into domains.
  */
 
-@SerialVersionUID(8037662401509425325l)
+@SerialVersionUID(8037662401509425325L)
 class FreebaseType(val domain: String, val typeName: String) extends OntologyType {
 
   override def getFullUri = FreebaseType.FREEBASE_RDF_PREFIX + domain + "." + typeName

--- a/core/src/main/scala/org/dbpedia/spotlight/model/TokenType.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/model/TokenType.scala
@@ -23,6 +23,6 @@ class TokenType(val id: Int, val tokenType: String, val count: Int) {
 }
 
 object TokenType {
-  val UNKNOWN  = new TokenType(0, "<<UNKNOWN>>", 1)
-  val STOPWORD = new TokenType(0, "<<STOPWORD>>", 1)
+  val UNKNOWN  = new TokenType(-1, "<<UNKNOWN>>", 1)
+  val STOPWORD = new TokenType(-2, "<<STOPWORD>>", 1)
 }

--- a/core/src/main/scala/org/dbpedia/spotlight/util/AnnotationFilter.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/util/AnnotationFilter.scala
@@ -17,14 +17,12 @@
 package org.dbpedia.spotlight.util
 
 import org.dbpedia.spotlight.log.SpotlightLog
-import scala.collection.JavaConversions._
-import java.io.File
 import org.dbpedia.spotlight.model._
 import org.dbpedia.spotlight.disambiguate.{DefaultDisambiguator, Disambiguator}
 import org.dbpedia.spotlight.string.ParseSurfaceFormText
 import org.dbpedia.spotlight.sparql.SparqlQueryExecuter
 import org.dbpedia.spotlight.exceptions.InputException
-import java.net.URLEncoder
+import scala.collection.JavaConversions._
 
 @deprecated("please use org.dbpedia.spotlight.filter.annotations.CombineAllAnnotationFilters")
 class AnnotationFilter(val config: SpotlightConfiguration)
@@ -273,7 +271,7 @@ class AnnotationFilter(val config: SpotlightConfiguration)
         import scala.collection.JavaConversions._
         SpotlightLog.info(this.getClass, "Disambiguating... (%s)", disambiguator.name)
         val disambiguatedOccurrences : java.util.List[DBpediaResourceOccurrence] = disambiguator.disambiguate(selectedSpots)
-        val occurrences = asBuffer(disambiguatedOccurrences).toList
+        val occurrences = asScalaBuffer(disambiguatedOccurrences).toList
 
         SpotlightLog.info(this.getClass, "Filtering... ")
 

--- a/eval/pom.xml
+++ b/eval/pom.xml
@@ -132,7 +132,7 @@
 
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.compiler.version}</artifactId>
+            <artifactId>scalatest_2.10</artifactId>
         </dependency>
 
     </dependencies>

--- a/index/src/main/scala/org/dbpedia/spotlight/io/AllOccurrenceSource.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/io/AllOccurrenceSource.scala
@@ -16,14 +16,17 @@ package org.dbpedia.spotlight.io
  * limitations under the License.
  */
 
-import org.dbpedia.spotlight.string.WikiMarkupStripper
-import org.dbpedia.spotlight.model._
-import org.dbpedia.extraction.wikiparser._
+import java.io.File
+
 import org.dbpedia.extraction.sources.{Source, XMLSource}
-import org.dbpedia.spotlight.log.SpotlightLog
-import java.io.{File}
-import xml.{XML, Elem}
 import org.dbpedia.extraction.util.Language
+import org.dbpedia.extraction.wikiparser.impl.simple.SimpleWikiParser
+import org.dbpedia.extraction.wikiparser.{Namespace, NodeUtil}
+import org.dbpedia.spotlight.log.SpotlightLog
+import org.dbpedia.spotlight.model._
+import org.dbpedia.spotlight.string.WikiMarkupStripper
+
+import scala.xml.{Elem, XML}
 
 /**
  * Loads Occurrences from a wiki dump.
@@ -68,7 +71,7 @@ object AllOccurrenceSource
      */
     private class AllOccurrenceSource(wikiPages : Source, multiplyDisambigs : Int=MULTIPLY_DISAMBIGUATION_CONTEXT) extends OccurrenceSource
     {
-        val wikiParser = WikiParser()
+        val wikiParser = new SimpleWikiParser()
 
         override def foreach[U](f : DBpediaResourceOccurrence => U) : Unit =
         {

--- a/index/src/main/scala/org/dbpedia/spotlight/io/DisambiguationContextSource.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/io/DisambiguationContextSource.scala
@@ -16,14 +16,17 @@ package org.dbpedia.spotlight.io
  * limitations under the License.
  */
 
-import org.dbpedia.spotlight.string.WikiMarkupStripper
-import org.dbpedia.spotlight.model._
-import org.dbpedia.extraction.wikiparser._
-import org.dbpedia.extraction.sources.{WikiPage, Source, XMLSource}
-import org.dbpedia.spotlight.log.SpotlightLog
-import java.io.{File}
-import xml.{XML, Elem}
+import java.io.File
+
+import org.dbpedia.extraction.sources.{Source, WikiPage, XMLSource}
 import org.dbpedia.extraction.util.Language
+import org.dbpedia.extraction.wikiparser._
+import org.dbpedia.extraction.wikiparser.impl.simple.SimpleWikiParser
+import org.dbpedia.spotlight.log.SpotlightLog
+import org.dbpedia.spotlight.model._
+import org.dbpedia.spotlight.string.WikiMarkupStripper
+
+import scala.xml.{Elem, XML}
 
 /**
  * Loads descriptive text that occurs around entries in disambiguation pages from a wiki dump.
@@ -65,7 +68,8 @@ object DisambiguationContextSource
     }
 
     def wikiPageCopy(wikiPage: WikiPage, newSource: String) = {
-        new WikiPage(wikiPage.title, wikiPage.redirect, wikiPage.id, wikiPage.revision, wikiPage.timestamp, newSource)
+        new WikiPage(wikiPage.title, wikiPage.redirect, wikiPage.id, wikiPage.revision, wikiPage.timestamp,
+            wikiPage.contributorID, wikiPage.contributorName, newSource, wikiPage.format)
     }
 
     /**
@@ -75,7 +79,7 @@ object DisambiguationContextSource
     {
         val splitDisambiguations = """\n"""
         
-        val wikiParser = WikiParser()
+        val wikiParser = new SimpleWikiParser()
 
         override def foreach[U](f : DBpediaResourceOccurrence => U) : Unit =
         {

--- a/index/src/main/scala/org/dbpedia/spotlight/io/WikiOccurrenceSource.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/io/WikiOccurrenceSource.scala
@@ -16,12 +16,13 @@ package org.dbpedia.spotlight.io
  * limitations under the License.
  */
 
+import org.dbpedia.extraction.wikiparser.impl.simple.SimpleWikiParser
 import org.dbpedia.spotlight.string.WikiMarkupStripper
 import org.dbpedia.spotlight.model._
 import org.dbpedia.extraction.wikiparser._
 import org.dbpedia.extraction.sources.{MemorySource, WikiPage, Source, XMLSource}
 import org.dbpedia.spotlight.log.SpotlightLog
-import java.io.{PrintStream, FileOutputStream, File}
+import java.io.File
 import xml.{XML, Elem}
 import org.dbpedia.extraction.util.Language
 
@@ -83,7 +84,7 @@ object WikiOccurrenceSource
      */
     private class WikiOccurrenceSource(wikiPages : Source) extends OccurrenceSource
     {
-        val wikiParser = WikiParser()
+        val wikiParser = new SimpleWikiParser()
 
         override def foreach[U](f : DBpediaResourceOccurrence => U) : Unit =
         {

--- a/index/src/main/scala/org/dbpedia/spotlight/io/WikiPageContextSource.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/io/WikiPageContextSource.scala
@@ -23,6 +23,7 @@ import org.dbpedia.spotlight.string.WikiMarkupStripper
 import org.dbpedia.extraction.wikiparser._
 import org.dbpedia.spotlight.model.{DBpediaResource, Text, WikiPageContext}
 import org.dbpedia.extraction.util.Language
+import org.dbpedia.extraction.wikiparser.impl.simple.SimpleWikiParser
 
 /**
  * Created by IntelliJ IDEA.
@@ -56,7 +57,7 @@ object WikiPageContextSource
      */
     private class WikipediaPageContextSource(wikiPages : Source) extends WikiPageSource
     {
-        val wikiParser = WikiParser()
+        val wikiParser = new SimpleWikiParser()
 
         override def foreach[U](f : WikiPageContext => U) : Unit =
         {

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dbpedia.spotlight.version>0.7</dbpedia.spotlight.version>
 
         <java.compiler.version>1.6</java.compiler.version>
-        <scala.compiler.version>2.9.2</scala.compiler.version>
+        <scala.compiler.version>2.10.4</scala.compiler.version>
         <lucene.version>3.6.0</lucene.version>
         <jersey.version>1.10</jersey.version>
 
@@ -185,30 +185,27 @@
     -->
 
     <dependencies>
-        <dependency>
+        <!--<dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
             <version>${scala.compiler.version}</version>
             <scope>provided</scope>
-            <!--
-                License: Scala License
-                http://www.scala-lang.org/node/146
-            -->
-        </dependency>
-
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala.compiler.version}</version>
-            <!--
-                License: Scala License
-                http://www.scala-lang.org/node/146
-            -->
-        </dependency>
+        </dependency> -->
     </dependencies>
 
     <dependencyManagement>
         <dependencies>
+
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${scala.compiler.version}</version>
+                <!--
+                    License: Scala License
+                    http://www.scala-lang.org/node/146
+                -->
+            </dependency>
+
             <dependency>
                 <groupId>org.dbpedia.spotlight</groupId>
                 <artifactId>core</artifactId>
@@ -245,7 +242,7 @@
             <dependency>
                 <groupId>org.dbpedia.extraction</groupId>
                 <artifactId>core</artifactId>
-                <version>3.8</version>
+                <version>3.9</version>
                 <!--
                     License: Apache Software License, Version 2.0
                 -->
@@ -495,8 +492,8 @@
 
             <dependency>
                 <groupId>org.scalatest</groupId>
-                <artifactId>scalatest_2.9.2</artifactId>
-                <version>2.0.M4</version>
+                <artifactId>scalatest_2.10</artifactId>
+                <version>2.2.5</version>
                 <!--
                     License: Apache Software License, Version 2.0
                 -->
@@ -565,8 +562,8 @@
 
             <dependency>
                 <groupId>org.scalanlp</groupId>
-                <artifactId>breeze-learn_2.9.2</artifactId>
-                <version>0.1</version>
+                <artifactId>breeze-learn_2.10</artifactId>
+                <version>0.3</version>
                 <!--
                     License: Apache Software License, Version 2.0
                 -->
@@ -574,8 +571,8 @@
 
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
-                <artifactId>akka-actor</artifactId>
-                <version>2.0.5</version>
+                <artifactId>akka-actor_2.10</artifactId>
+                <version>2.2.3</version>
                 <!--
                     License: Apache Software License, Version 2.0
                 -->
@@ -653,8 +650,8 @@
 
             <dependency>
                 <groupId>org.scalaz</groupId>
-                <artifactId>scalaz-core_${scala.compiler.version}</artifactId>
-                <version>6.0.4</version>
+                <artifactId>scalaz-core_2.10</artifactId>
+                <version>7.0.5</version>
                 <!--
                   License: BSD 3-Clause
                 -->
@@ -727,8 +724,8 @@
 
             <dependency>
                 <groupId>net.liftweb</groupId>
-                <artifactId>lift-json_2.9.2</artifactId>
-                <version>2.5-M1</version>
+                <artifactId>lift-json_2.10</artifactId>
+                <version>2.5</version>
                 <!--
                   License: Apache Software License, Version 2.0
                 -->
@@ -783,7 +780,7 @@
             <dependency>
                 <groupId>cc.factorie</groupId>
                 <artifactId>factorie</artifactId>
-                <version>1.0.0-M4</version>
+                <version>1.0.0-RC1</version>
                 <!--
                   License: Apache Software License, Version 2.0
                 -->
@@ -959,6 +956,11 @@
             <url>https://github.com/dbpedia-spotlight/maven-repo/raw/master/snapshots</url>
         </repository>
 
+        <repository>
+            <id>maven.aksw.internal</id>
+            <name>University Leipzig, AKSW Maven2 Repository</name>
+            <url>http://maven.aksw.org/archiva/repository/internal</url>
+        </repository>
 
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-actor_2.10</artifactId>
-                <version>2.2.3</version>
+                <version>2.3.4</version>
                 <!--
                     License: Apache Software License, Version 2.0
                 -->
@@ -725,7 +725,7 @@
             <dependency>
                 <groupId>net.liftweb</groupId>
                 <artifactId>lift-json_2.10</artifactId>
-                <version>2.5</version>
+                <version>2.5.3</version>
                 <!--
                   License: Apache Software License, Version 2.0
                 -->


### PR DESCRIPTION
Fixes #382.

Change the id of TokenTypes UNKNOWN and STOPWORD to avoid the conflict with id 0, which is used for a regular TokenType.