### PR TITLE
Fix TokenType id conflict. #382

### DIFF
--- a/core/src/main/scala/org/dbpedia/spotlight/db/memory/MemoryTokenTypeStore.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/db/memory/MemoryTokenTypeStore.scala
@@ -2,9 +2,7 @@ package org.dbpedia.spotlight.db.memory
 
 import org.dbpedia.spotlight.log.SpotlightLog
 import org.dbpedia.spotlight.db.model.TokenTypeStore
-import java.lang.String
 import org.dbpedia.spotlight.model.TokenType
-import scala.transient
 import util.StringToIDMapFactory
 
 /**
@@ -67,9 +65,14 @@ class MemoryTokenTypeStore
   }
 
   def getTokenTypeByID(id: Int): TokenType = {
-    val token = tokenForId(id)
-    val count = counts(id)
-    new TokenType(id, token, count)
+    id match {
+      case TokenType.UNKNOWN.id => TokenType.UNKNOWN
+      case TokenType.STOPWORD.id => TokenType.STOPWORD
+      case regularId =>
+        val token = tokenForId(regularId)
+        val count = counts(regularId)
+        new TokenType(regularId, token, count)
+    }
   }
 
   def getTotalTokenCount: Double = totalTokenCount

--- a/core/src/main/scala/org/dbpedia/spotlight/model/TokenType.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/model/TokenType.scala
@@ -23,6 +23,6 @@ class TokenType(val id: Int, val tokenType: String, val count: Int) {
 }
 
 object TokenType {
-  val UNKNOWN  = new TokenType(0, "<<UNKNOWN>>", 1)
-  val STOPWORD = new TokenType(0, "<<STOPWORD>>", 1)
+  val UNKNOWN  = new TokenType(-1, "<<UNKNOWN>>", 1)
+  val STOPWORD = new TokenType(-2, "<<STOPWORD>>", 1)
 }

--- a/core/src/test/scala/org/dbpedia/spotlight/Helper.scala
+++ b/core/src/test/scala/org/dbpedia/spotlight/Helper.scala
@@ -1,0 +1,51 @@
+package org.dbpedia.spotlight
+
+import org.dbpedia.spotlight.db.memory.{MemoryContextStore, MemoryQuantizedCountStore, MemoryTokenTypeStore}
+import org.dbpedia.spotlight.db.model.TokenTypeStore
+import org.dbpedia.spotlight.model.{DBpediaResource, TokenType}
+
+
+object Helper {
+
+  def createTokenTypeStore(tokenTypes: List[TokenType]): MemoryTokenTypeStore = {
+
+    val tokenTypeStore = new MemoryTokenTypeStore()
+    val tokens = new Array[String](tokenTypes.size + 1)
+    val counts = new Array[Int](tokenTypes.size + 1)
+
+    tokenTypes.foreach(token => {
+      tokens(token.id) = token.tokenType
+      counts(token.id) = token.count
+    })
+
+    tokenTypeStore.tokenForId = tokens
+    tokenTypeStore.counts = counts
+    tokenTypeStore.loaded()
+
+    tokenTypeStore
+  }
+
+  def createContextStore(occs: List[(DBpediaResource, Array[TokenType], Array[Int])],
+                         tokenStore: TokenTypeStore,
+                         quantizedCountStore: MemoryQuantizedCountStore): MemoryContextStore = {
+
+    val numResources = occs.size
+    val tokens = new Array[Array[Int]](numResources)
+    val counts = new Array[Array[Short]](numResources)
+
+    occs.foreach { case (res, uriTokens, uriCounts) =>
+      tokens(res.id) = uriTokens.map(_.id)
+      counts(res.id) = uriCounts.map { count => quantizedCountStore.addCount(count) }
+    }
+
+    val contextStore = new MemoryContextStore()
+    contextStore.tokens = tokens
+    contextStore.counts = counts
+    contextStore.tokenStore = tokenStore
+    contextStore.quantizedCountStore = quantizedCountStore
+    contextStore.totalTokenCounts = new Array[Int](numResources)
+    contextStore.calculateTotalTokenCounts()
+    contextStore
+  }
+
+}

--- a/core/src/test/scala/org/dbpedia/spotlight/db/similarity/TestGenerativeContextSimilarity.scala
+++ b/core/src/test/scala/org/dbpedia/spotlight/db/similarity/TestGenerativeContextSimilarity.scala
@@ -2,7 +2,8 @@ package org.dbpedia.spotlight.db.similarity
 
 import org.dbpedia.spotlight.db.memory.MemoryQuantizedCountStore
 import org.dbpedia.spotlight.model.{DBpediaResource, TokenType}
-import org.dbpedia.spotlight.Helper.{createContextStore, createTokenTypeStore}
+import org.dbpedia.spotlight.util.MemoryStoreUtil
+import MemoryStoreUtil.{createContextStore, createTokenTypeStore}
 import org.junit.Assert._
 import org.junit.Test
 

--- a/core/src/test/scala/org/dbpedia/spotlight/db/similarity/TestGenerativeContextSimilarity.scala
+++ b/core/src/test/scala/org/dbpedia/spotlight/db/similarity/TestGenerativeContextSimilarity.scala
@@ -1,0 +1,31 @@
+package org.dbpedia.spotlight.db.similarity
+
+import org.dbpedia.spotlight.db.memory.MemoryQuantizedCountStore
+import org.dbpedia.spotlight.model.{DBpediaResource, TokenType}
+import org.dbpedia.spotlight.Helper.{createContextStore, createTokenTypeStore}
+import org.junit.Assert._
+import org.junit.Test
+
+
+class TestGenerativeContextSimilarity {
+
+  @Test
+  def testIntersectWithStopWordToken() {
+
+    val res = new DBpediaResource("some uri")
+    val token0 = new TokenType(0, "token0", 3)
+    val token1 = new TokenType(1, "token1", 5)
+    val token2 = new TokenType(2, "token2", 4)
+    val occs = List((res, Array(token0, token1), Array(10, 12)))
+
+    val tokenTypeStore = createTokenTypeStore(List(token0, token1, token2))
+    val quantizedCountStore = new MemoryQuantizedCountStore()
+    val contextStore = createContextStore(occs, tokenTypeStore, quantizedCountStore)
+    val gcs = new GenerativeContextSimilarity(tokenTypeStore, contextStore)
+
+    val query = List(TokenType.STOPWORD, TokenType.UNKNOWN, token1, token2)
+    val intersection = gcs.intersect(query, res).filterNot { case (token, count) => count == 0 }
+    assertEquals(Seq((token1, 12)), intersection)
+  }
+
+}

--- a/core/src/test/scala/org/dbpedia/spotlight/db/spotter/TestSfFSASpotter.scala
+++ b/core/src/test/scala/org/dbpedia/spotlight/db/spotter/TestSfFSASpotter.scala
@@ -19,7 +19,7 @@ package org.dbpedia.spotlight.db.spotter
 
 import java.util.Locale
 
-import org.dbpedia.spotlight.Helper.createTokenTypeStore
+import org.dbpedia.spotlight.util.MemoryStoreUtil.createTokenTypeStore
 import org.dbpedia.spotlight.db.model.Stemmer
 import org.dbpedia.spotlight.db.tokenize.{LanguageIndependentTokenizer, LanguageIndependentStringTokenizer}
 import org.dbpedia.spotlight.model.TokenType

--- a/core/src/test/scala/org/dbpedia/spotlight/db/spotter/TestSfFSASpotter.scala
+++ b/core/src/test/scala/org/dbpedia/spotlight/db/spotter/TestSfFSASpotter.scala
@@ -19,7 +19,7 @@ package org.dbpedia.spotlight.db.spotter
 
 import java.util.Locale
 
-import org.dbpedia.spotlight.db.memory.MemoryTokenTypeStore
+import org.dbpedia.spotlight.Helper.createTokenTypeStore
 import org.dbpedia.spotlight.db.model.Stemmer
 import org.dbpedia.spotlight.db.tokenize.{LanguageIndependentTokenizer, LanguageIndependentStringTokenizer}
 import org.dbpedia.spotlight.model.TokenType
@@ -303,7 +303,7 @@ class TestSfFSASpotter{
     } )
 
     //Initalizing the Memory Token Store
-    val tokenTypeStore = TestSfFSASpotter.createTokenTypeStore(tokenTypes.toList)
+    val tokenTypeStore = createTokenTypeStore(tokenTypes.toList)
 
     //Creating a sample StopWords
     val stopWords = Set[String]("a","the","an","that")
@@ -321,26 +321,4 @@ class TestSfFSASpotter{
   }
 }
 
-
-object TestSfFSASpotter {
-
-  def createTokenTypeStore(tokenTypes:List[TokenType]): MemoryTokenTypeStore =  {
-
-    val tokenTypeStore = new MemoryTokenTypeStore()
-    val tokens = new Array[String](tokenTypes.size + 1)
-    val counts = new Array[Int](tokenTypes.size + 1)
-
-    tokenTypes.foreach(token => {
-      tokens(token.id) = token.tokenType
-      counts(token.id) = token.count
-
-    })
-
-    tokenTypeStore.tokenForId  = tokens.array
-    tokenTypeStore.counts = counts.array
-    tokenTypeStore.loaded()
-
-    return tokenTypeStore
-  }
-}
 

--- a/core/src/test/scala/org/dbpedia/spotlight/util/MemoryStoreUtil.scala
+++ b/core/src/test/scala/org/dbpedia/spotlight/util/MemoryStoreUtil.scala
@@ -1,11 +1,11 @@
-package org.dbpedia.spotlight
+package org.dbpedia.spotlight.util
 
 import org.dbpedia.spotlight.db.memory.{MemoryContextStore, MemoryQuantizedCountStore, MemoryTokenTypeStore}
 import org.dbpedia.spotlight.db.model.TokenTypeStore
 import org.dbpedia.spotlight.model.{DBpediaResource, TokenType}
 
 
-object Helper {
+object MemoryStoreUtil {
 
   def createTokenTypeStore(tokenTypes: List[TokenType]): MemoryTokenTypeStore = {
 
@@ -25,8 +25,7 @@ object Helper {
     tokenTypeStore
   }
 
-  def createContextStore(occs: List[(DBpediaResource, Array[TokenType], Array[Int])],
-                         tokenStore: TokenTypeStore,
+  def createContextStore(occs: List[(DBpediaResource, Array[TokenType], Array[Int])], tokenStore: TokenTypeStore,
                          quantizedCountStore: MemoryQuantizedCountStore): MemoryContextStore = {
 
     val numResources = occs.size


### PR DESCRIPTION
Fixes #382.

Change the id of TokenTypes UNKNOWN and STOPWORD to avoid the conflict with id 0, which is used for a regular TokenType.