### PR TITLE
OpenNLPTokenizer optimization and new features

### DIFF
--- a/core/src/main/scala/org/dbpedia/spotlight/db/tokenize/OpenNLPTokenizer.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/db/tokenize/OpenNLPTokenizer.scala
@@ -1,7 +1,7 @@
 package org.dbpedia.spotlight.db.tokenize
 
-import opennlp.tools.sentdetect.SentenceDetector
-import opennlp.tools.postag.POSTagger
+import opennlp.tools.sentdetect.SentenceDetectorME
+import opennlp.tools.postag.POSTaggerME
 import org.dbpedia.spotlight.model.{Feature, TokenType, Token, Text}
 import opennlp.tools.util.Span
 import org.dbpedia.spotlight.db.model.{TokenTypeStore, Stemmer}
@@ -11,22 +11,36 @@ import org.dbpedia.spotlight.db.model.{TokenTypeStore, Stemmer}
  */
 
 class OpenNLPTokenizer(
-  tokenizer: opennlp.tools.tokenize.Tokenizer,
+  tokenizer: opennlp.tools.tokenize.TokenizerME,
   stopWords: Set[String],
   stemmer: Stemmer,
-  sentenceDetector: SentenceDetector,
-  var posTagger: POSTagger,
+  sentenceDetector: SentenceDetectorME,
+  var posTagger: POSTaggerME,
   tokenTypeStore: TokenTypeStore
 ) extends BaseTextTokenizer(tokenTypeStore, stemmer) {
 
+  def sentsProbs = _sentsProbs
+  def tokensProbs = _tokensProbs
+  def posTagsProbs = _posTagsProbs
+
+  private var _sentsProbs: Array[Double] = null
+  private var _tokensProbs: Array[Double] = null
+  private var _posTagsProbs:Array[Double] = null
+
   def tokenize(text: Text): List[Token] = this.synchronized {
-    sentenceDetector.sentPosDetect(text.text).map{ sentencePos: Span =>
+    val sents = sentenceDetector.sentPosDetect(text.text)
+    this._sentsProbs = sentenceDetector.getSentenceProbabilities()
+    var tokensProbsList = List[Array[Double]]()
+    var posTagsProbsList = List[Array[Double]]()
+    val res = sents.map{ sentencePos: Span =>
       val sentence = sentencePos.getCoveredText(text.text).toString()
 
       val sentenceTokenPos = tokenizer.tokenizePos(sentence)
       val sentenceTokens   = Span.spansToStrings(sentenceTokenPos, sentence)
       val posTags          = if(posTagger != null) posTagger.tag(sentenceTokens) else Array[String]()
 
+      tokensProbsList +:= tokenizer.getTokenProbabilities()
+      posTagsProbsList +:= posTagger.probs()
       (0 to sentenceTokens.size-1).map{ i: Int =>
         val token = if (stopWords contains sentenceTokens(i)) {
           new Token(sentenceTokens(i), sentencePos.getStart + sentenceTokenPos(i).getStart, TokenType.STOPWORD)
@@ -43,6 +57,9 @@ class OpenNLPTokenizer(
         token
       }
     }.flatten.toList
+    this._tokensProbs = tokensProbsList.reverse.flatten.toArray
+    this._posTagsProbs = posTagsProbsList.reverse.flatten.toArray
+    res
   }
 
   def getStringTokenizer: BaseStringTokenizer = new OpenNLPStringTokenizer(tokenizer, stemmer)

--- a/core/src/main/scala/org/dbpedia/spotlight/db/tokenize/OpenNLPTokenizer.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/db/tokenize/OpenNLPTokenizer.scala
@@ -21,11 +21,10 @@ class OpenNLPTokenizer(
 
   def tokenize(text: Text): List[Token] = this.synchronized {
     sentenceDetector.sentPosDetect(text.text).map{ sentencePos: Span =>
+      val sentence = sentencePos.getCoveredText(text.text).toString()
 
-      val sentence = text.text.substring(sentencePos.getStart, sentencePos.getEnd)
-
-      val sentenceTokens   = tokenizer.tokenize(sentence)
       val sentenceTokenPos = tokenizer.tokenizePos(sentence)
+      val sentenceTokens   = Span.spansToStrings(sentenceTokenPos, sentence)
       val posTags          = if(posTagger != null) posTagger.tag(sentenceTokens) else Array[String]()
 
       (0 to sentenceTokens.size-1).map{ i: Int =>


### PR DESCRIPTION
**Optimize OpenNLPTokenizer**
Avoid tokenizing twice each sentence
Use getCoveredText() method to get sentences string covered by the span

**Keep opennlp analysis probabilites**
Add the following properties to OpenNLPTokenizer
- sentsProbs Array[Double]
- tokensProbs: Array[Double]
- posTagsProbs: Array[Double]