### PR TITLE
OpenNLPTokenizer optimization and new features

### DIFF
--- a/core/src/main/scala/org/dbpedia/spotlight/db/tokenize/OpenNLPTokenizer.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/db/tokenize/OpenNLPTokenizer.scala
@@ -21,11 +21,10 @@ class OpenNLPTokenizer(
 
   def tokenize(text: Text): List[Token] = this.synchronized {
     sentenceDetector.sentPosDetect(text.text).map{ sentencePos: Span =>
+      val sentence = sentencePos.getCoveredText(text.text).toString()
 
-      val sentence = text.text.substring(sentencePos.getStart, sentencePos.getEnd)
-
-      val sentenceTokens   = tokenizer.tokenize(sentence)
       val sentenceTokenPos = tokenizer.tokenizePos(sentence)
+      val sentenceTokens   = Span.spansToStrings(sentenceTokenPos, sentence)
       val posTags          = if(posTagger != null) posTagger.tag(sentenceTokens) else Array[String]()
 
       (0 to sentenceTokens.size-1).map{ i: Int =>


### PR DESCRIPTION
Optimize OpenNLPTokenizer
Avoid tokenizing twice each sentence
Use getCoveredText() method to get sentences string covered by the span

Keep opennlp analysis probabilites
Add the following properties to OpenNLPTokenizer
- prob: the opennlp token probability (Double)
- posProbs: the opennlp postag probability (Double)